### PR TITLE
feat: :sparkles: Add sweetalert2 to resolve deployment error

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,6 +16,7 @@
         "react": "^18",
         "react-dom": "^18",
         "react-hook-form": "^7.51.2",
+        "sweetalert2": "^11.10.8",
         "sweetalert2-react-content": "^5.0.7",
         "use-debounce": "^10.0.0",
         "yup": "^1.4.0",
@@ -4667,7 +4668,6 @@
       "version": "11.10.8",
       "resolved": "https://registry.npmjs.org/sweetalert2/-/sweetalert2-11.10.8.tgz",
       "integrity": "sha512-oAkYROBfXBY+4sVbQEIcN+ZxAx69lsmz5WEBwdEpyS4m59vOBNlRU5/fJpAI1MVfiDwFZiGwVzB/KBpOyfLNtg==",
-      "peer": true,
       "funding": {
         "type": "individual",
         "url": "https://github.com/sponsors/limonte"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "react": "^18",
     "react-dom": "^18",
     "react-hook-form": "^7.51.2",
+    "sweetalert2": "^11.10.8",
     "sweetalert2-react-content": "^5.0.7",
     "use-debounce": "^10.0.0",
     "yup": "^1.4.0",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2572,7 +2572,7 @@ sweetalert2-react-content@^5.0.7:
   resolved "https://registry.npmjs.org/sweetalert2-react-content/-/sweetalert2-react-content-5.0.7.tgz"
   integrity sha512-8Fk82Mpk45lFXpJWKIFF/lq8k/dJKDDQGFcuqVosaL/qRdViyAs5+u37LoTGfnOIvf+rfQB3PAXcp1XLLn+0ew==
 
-sweetalert2@^11.0.0:
+sweetalert2@^11.0.0, sweetalert2@^11.10.8:
   version "11.10.8"
   resolved "https://registry.npmjs.org/sweetalert2/-/sweetalert2-11.10.8.tgz"
   integrity sha512-oAkYROBfXBY+4sVbQEIcN+ZxAx69lsmz5WEBwdEpyS4m59vOBNlRU5/fJpAI1MVfiDwFZiGwVzB/KBpOyfLNtg==


### PR DESCRIPTION
Include sweetalert2 in dependencies to fix an error encountered during deployment, ensuring smooth operation of alert features.

Important changes:
- Added sweetalert2 version 11.10.8 to dependencies to resolve a specific deployment error.
- Updated package.json and package-lock.json to include sweetalert2.
- Modified yarn.lock to align with the new dependency version.